### PR TITLE
Add custom header labeling and JSON flattening for improved CSV output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 - JSON to YAML Conversion.
-- Option to specify header labels in CSV output.
+
+## [1.0.2] - 2025-01-06
+
+### Added
+
+- Custom header labels for CSV: Allows specifying friendly column names instead of using raw JSON keys.
+- Nested object flattening in CSV: Transforms nested fields (e.g. `details.age`) into separate columns.
+- Type-based CSV output: Numbers are unquoted, strings are quoted, and `null/undefined` fields are left empty.
+- Large dataset test coverage: Ensures performance and correctness for bigger JSON arrays.
+
+### Fixed
+
+- Incorrectly quoted numeric fields in CSV outputs.
+- Inconsistent handling of empty or null fields when generating CSV.
 
 ## [1.0.1] - 2025-01-04
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## Features
 
-- 🚀 Convert to CSV: Easily transform JSON arrays into CSV files.
-- 📄 Generate Markdown tables: Convert JSON arrays into neatly formatted Markdown tables.
-- 📂 Convert to XML: Transform JSON objects into well-structured XML.
-- 🔧 Compatible with JavaScript and TypeScript: Ideal for modern projects.
+- 🚀 **Convert to CSV**: Easily transform JSON arrays into CSV files, with optional header mapping and nested object flattening.
+- 📄 **Generate Markdown tables**: Convert JSON arrays into neatly formatted Markdown tables.
+- 📂 **Convert to XML**: Transform JSON objects into well-structured XML.
+- 🔧 **Compatible with JavaScript and TypeScript**: Ideal for modern projects.
 
 ## Installation
 
@@ -41,7 +41,7 @@ import { jsonweaver } from "jsonweaver";
 
 ### Examples
 
-JSON to CSV
+JSON to CSV (Basic usage, no custom headers, no flatten):
 
 ```javascript
 const json = [
@@ -51,6 +51,44 @@ const json = [
 
 const csv = jsonweaver.toCSV(json);
 console.log(csv);
+```
+
+Using custom headers (To rename the keys in the CSV "e.g., name → Full Name, age → Years"):
+
+```javascript
+const headerMapping = {
+  name: "Full Name",
+  age: "Years",
+};
+
+const csvWithHeaders = jsonweaver.toCSV(json, headerMapping);
+console.log(csvWithHeaders);
+/*
+  "Full Name","Years"
+  "Alice",25
+  "Bob",30
+*/
+```
+
+Flatten nested objects (If the JSON contains nested objects, for instance):
+
+```javascript
+const json = [
+  { name: "Alice", details: { age: 25, city: "Wonderland" } },
+  { name: "Bob", details: { age: 30, city: "Gotham" } },
+];
+```
+
+Then `toCSV` can transform nested fields into separate columns:
+
+```javascript
+const csvFlattened = jsonweaver.toCSV(json, headerMapping, { flatten: true });
+console.log(csvFlattened);
+/*
+  "name","details.age","details.city"
+  "Alice",25,"Wonderland"
+  "Bob",30,"Gotham"
+*/
 ```
 
 JSON to XML
@@ -76,11 +114,14 @@ console.log(markdownTable);
 
 ### API
 
-| Function                          | Description                                                        |
-| --------------------------------- | ------------------------------------------------------------------ |
-| `toCSV(json: object[])`           | Converts an array of JSON objects into a CSV string.               |
-| `toXML(json: object)`             | Converts a JSON object into an XML string.                         |
-| `toMarkdownTable(json: object[])` | Converts an array of JSON objects into a formatted Markdown table. |
+| Function                                   | Description                                                                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `toCSV(json: object[], headerMap?, opts?)` | Converts an array of JSON objects into a CSV string. Supports optional header mapping and nested object flattening. |
+| `toXML(json: object)`                      | Converts a JSON object into an XML string.                                                                          |
+| `toMarkdownTable(json: object[])`          | Converts an array of JSON objects into a formatted Markdown table.                                                  |
+
+**headerMap**: is an object mapping JSON keys to custom column labels.
+**opts?.flatten**: is a boolean indicating whether to flatten nested objects.
 
 ### Requirements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,24 @@
 {
   "name": "jsonweaver",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonweaver",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "1.0.2",
+      "license": "MIT",
       "dependencies": {
-        "json2csv": "^6.0.0-alpha.2",
         "xmlbuilder": "^15.1.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/json2csv": "^5.0.7",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -919,12 +920,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@streamparser/json": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.6.tgz",
-      "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1016,16 +1011,6 @@
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
-      }
-    },
-    "node_modules/@types/json2csv": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json2csv/-/json2csv-5.0.7.tgz",
-      "integrity": "sha512-Ma25zw9G9GEBnX8b12R4EYvnFT6dBh8L3jwsN5EUFXa+fl2dqmbLDbNWN0XuQU3rSXdsbBeCYjI9uHU2PUBxhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -1488,15 +1473,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2842,24 +2818,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json2csv": {
-      "version": "6.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-6.0.0-alpha.2.tgz",
-      "integrity": "sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@streamparser/json": "^0.0.6",
-        "commander": "^6.2.0",
-        "lodash.get": "^4.4.2"
-      },
-      "bin": {
-        "json2csv": "bin/json2csv.js"
-      },
-      "engines": {
-        "node": ">= 12",
-        "npm": ">= 6.13.0"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2912,12 +2870,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,10 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "json2csv": "^6.0.0-alpha.2",
     "xmlbuilder": "^15.1.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/json2csv": "^5.0.7",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonweaver",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A simple utility to transform JSON data into CSV, XML, and Markdown table formats.",
   "keywords": [
     "json",

--- a/src/converters/toCSV.ts
+++ b/src/converters/toCSV.ts
@@ -1,4 +1,3 @@
-import { Parser } from 'json2csv';
 import { FieldGenerator, HeaderMapping, JSONArray, JSONObject } from '../types';
 
 const defaultCSVFieldGenerator: FieldGenerator = (json) => {

--- a/src/converters/toCSV.ts
+++ b/src/converters/toCSV.ts
@@ -1,11 +1,74 @@
 import { Parser } from 'json2csv';
-import { JSONArray } from '../types';
+import { FieldGenerator, HeaderMapping, JSONArray, JSONObject } from '../types';
 
-export const toCSV = (json: JSONArray): string => {
-  if (json.length === 0) {
-    return '';
-  }
+const defaultCSVFieldGenerator: FieldGenerator = (json) => {
+  const allKeys = Array.from(new Set(json.flatMap(item => Object.keys(item))));
 
-  const parser = new Parser();
-  return parser.parse(json);
+  return allKeys.map(key => ({
+    label: key,
+    value: key
+  }));
+};
+
+export const customCSVFieldGenerator = (headerMapping: HeaderMapping): FieldGenerator => {
+  return () => {
+    return Object.keys(headerMapping).map(key => ({
+      label: headerMapping[key],
+      value: key
+    }));
+  };
+};
+
+const flattenObject = (obj: JSONObject, prefix = ''): JSONObject => {
+  return Object.entries(obj).reduce((acc: JSONObject, [key, value]) => {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(acc, flattenObject(value, newKey));
+    } else {
+      acc[newKey] = value;
+    }
+
+    return acc;
+  }, {});
+};
+
+const flattenJSON = (json: JSONArray): JSONArray => {
+  return json.map((item) => flattenObject(item as JSONObject));
+};
+
+export const toCSV = (
+  json: JSONArray,
+  fieldGenerator: FieldGenerator = defaultCSVFieldGenerator
+): string => {
+  if (json.length === 0) return '';
+
+  const flattenedJSON = flattenJSON(json);
+
+  const allObjectsEmpty = flattenedJSON.every(item => Object.keys(item).length === 0);
+  if (allObjectsEmpty) return '';
+
+  const fields = fieldGenerator(flattenedJSON);
+
+  const headers = fields.map(field => `"${field.label}"`).join(',');
+
+  const rows = flattenedJSON.map((row) =>
+    fields
+      .map((field) => {
+        const value = row[field.value as string];
+
+        if (value === null || value === undefined) {
+          return '';
+        } else if (typeof value === 'string') {
+          return `"${value.replace(/"/g, '""')}"`;
+        } else if (typeof value === 'number') {
+          return `${value}`;
+        } else {
+          return `"${String(value).replace(/"/g, '""')}"`;
+        }
+      })
+      .join(',')
+  );
+
+  return [headers, ...rows].join('\n');
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,18 @@
+export type JSONObject = Record<string, any>;
+export type JSONArray = JSONObject[];
+
+export interface HeaderMapping {
+  [key: string]: string;
+}
+
 export type ToXMLOptions = {
   maxDepth?: number;
   arrayHandling?: 'wrap' | 'index';
 };
 
-export type JSONObject = Record<string, any>;
+type Field = {
+  label: string;
+  value: string | ((row: Record<string, any>) => string);
+};
 
-export type JSONArray = JSONObject[];
+export type FieldGenerator = (json: JSONArray) => Field[];

--- a/tests/toCSV.test.ts
+++ b/tests/toCSV.test.ts
@@ -1,16 +1,17 @@
-import { toCSV } from '../src/converters/toCSV';
+import { customCSVFieldGenerator, toCSV } from '../src/converters/toCSV';
 
 describe('toCSV Function', () => {
   it('should convert JSON to CSV', () => {
     const json = [{ name: 'Alice', age: 25 }, { name: 'Bob', age: 30 }];
     const csv = toCSV(json);
-
+  
     const expectedCSV = `"name","age"
 "Alice",25
 "Bob",30`;
-
-    expect(csv).toBe(expectedCSV); 
+  
+    expect(csv).toBe(expectedCSV);
   });
+  
 
   it('should return empty string for empty JSON array', () => {
     const json: [] = [];
@@ -23,26 +24,141 @@ describe('toCSV Function', () => {
     const json = [
       { name: 'Alice', age: 25 },
       { name: 'Bob' },
-      { name: 'Charlie', age: 30, city: 'New York' }
+      { name: 'Charlie', age: 30, city: 'New York' },
     ];
     const csv = toCSV(json);
-
+  
     const expectedCSV = `"name","age","city"
 "Alice",25,
 "Bob",,
 "Charlie",30,"New York"`;
-
+  
     expect(csv).toBe(expectedCSV);
-  });
+  });  
 
   it('should handle JSON with null or undefined values', () => {
     const json = [{ name: 'Alice', age: null }, { name: undefined, age: 30 }];
     const csv = toCSV(json);
+  
+    const expectedCSV = `"name","age"
+"Alice",
+,30`;
+  
+    expect(csv).toBe(expectedCSV);
+  });
+  
+
+  it('should use custom field generator with header mapping', () => {
+    const json = [
+      { firstName: 'Alice', lastName: 'Doe', age: 25 },
+      { firstName: 'Bob', lastName: 'Smith', age: 30 },
+    ];
+    const headerMapping = {
+      firstName: 'First Name',
+      lastName: 'Last Name',
+      age: 'Age',
+    };
+
+    const csv = toCSV(json, customCSVFieldGenerator(headerMapping));
+
+    const expectedCSV = `"First Name","Last Name","Age"
+"Alice","Doe",25
+"Bob","Smith",30`;
+
+    expect(csv).toBe(expectedCSV);
+  });
+
+  it('should handle deeply nested JSON objects gracefully', () => {
+    const json = [
+      { name: 'Alice', details: { age: 25, city: 'New York' } },
+      { name: 'Bob', details: { age: 30, city: 'Los Angeles' } },
+    ];
+    const csv = toCSV(json);
+
+    const expectedCSV = `"name","details.age","details.city"
+"Alice",25,"New York"
+"Bob",30,"Los Angeles"`;
+
+    expect(csv).toBe(expectedCSV);
+  });
+
+  it('should escape special characters in strings', () => {
+    const json = [
+      { name: 'Alice', description: 'Likes "cats" and, dogs.' },
+      { name: 'Bob', description: 'Enjoys, "coding"' },
+    ];
+    const csv = toCSV(json);
+  
+    const expectedCSV = `"name","description"
+"Alice","Likes ""cats"" and, dogs."
+"Bob","Enjoys, ""coding"""`;
+  
+    expect(csv).toBe(expectedCSV);
+  });
+  
+
+  it('should handle an array of arrays instead of objects', () => {
+    const json = [
+      ['Name', 'Age', 'City'],
+      ['Alice', 25, 'New York'],
+      ['Bob', 30, 'Los Angeles'],
+    ] as any;
+
+    const csv = toCSV(json);
+
+    const expectedCSV = `"0","1","2"
+"Name","Age","City"
+"Alice",25,"New York"
+"Bob",30,"Los Angeles"`;
+
+    expect(csv).toBe(expectedCSV);
+  });
+
+  it('should handle data with a single object', () => {
+    const json = [{ name: 'Alice', age: 25 }];
+    const csv = toCSV(json);
+
+    const expectedCSV = `"name","age"
+"Alice",25`;
+
+    expect(csv).toBe(expectedCSV);
+  });
+
+  it('should handle an array with only one key in some objects', () => {
+    const json = [
+      { name: 'Alice' },
+      { name: 'Bob' },
+      { age: 30 },
+    ];
+    const csv = toCSV(json);
 
     const expectedCSV = `"name","age"
 "Alice",
+"Bob",
 ,30`;
 
     expect(csv).toBe(expectedCSV);
   });
+
+  it('should return empty string for an array of empty objects', () => {
+    const json = [{}, {}, {}];
+    const csv = toCSV(json);
+
+    expect(csv).toBe('');
+  });
+
+  it('should correctly handle large datasets', () => {
+    const json = Array.from({ length: 1000 }, (_, i) => ({
+      id: i + 1,
+      value: `Value ${i + 1}`,
+    }));
+    const csv = toCSV(json);
+  
+    const expectedCSV = [
+      `"id","value"`,
+      ...Array.from({ length: 1000 }, (_, i) => `${i + 1},"Value ${i + 1}"`),
+    ].join('\n');
+  
+    expect(csv).toBe(expectedCSV);
+  });  
 });


### PR DESCRIPTION
- Implements custom header labels mapping for CSV columns (JSON key → user-friendly label).
- Flattens nested objects, turning sub-fields (e.g., `address.city`) into separate columns.
- Distinguishes between strings (quoted), numbers (unquoted), and null/undefined (empty).
- Improves CSV readability and provides flexibility for header customization.





