### PR TITLE
Add Support for YAML Conversion, JSONLines, and JSONLines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-- JSON to YAML Conversion.
+- JSON Schema Validation
+- Pretty-Print for XML Output
+- Batch Processing
+
+## [1.1.0] - 2025-01-09
+
+### Added
+
+- JSON to YAML Conversion: Added support for converting JSON to YAML for configurations like Kubernetes and Ansible.
+- JSON to JSONLines (NDJSON): Transform JSON arrays into JSONLines, ideal for incremental processing and data pipelines.
+- JSONLines Stream: Generate readable streams of JSONLines to handle large volumes of data efficiently.
+
+### Fixed
+
+- General improvements in input validation for existing functions.
+- Memory optimizations for large conversions.
 
 ## [1.0.2] - 2025-01-06
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # jsonweaver
 
-**jsonweaver** is a powerful and easy-to-use library for transforming JSON data into popular formats such as CSV, XML, and Markdown tables.
+**jsonweaver** is a powerful and easy-to-use library for transforming JSON data into popular formats such as CSV, XML, Markdown tables, YAML, and JSONLines (NDJSON).
 
 ## Features
 
 - 🚀 **Convert to CSV**: Easily transform JSON arrays into CSV files, with optional header mapping and nested object flattening.
 - 📄 **Generate Markdown tables**: Convert JSON arrays into neatly formatted Markdown tables.
 - 📂 **Convert to XML**: Transform JSON objects into well-structured XML.
+- 📜 **Convert to YAML**: Seamlessly transform JSON into YAML format for configuration files and more.
+- 📦 **Convert to JSONLines (NDJSON)**: Convert JSON arrays to JSONLines format for large-scale data processing and streaming.
 - 🔧 **Compatible with JavaScript and TypeScript**: Ideal for modern projects.
 
 ## Installation
@@ -41,7 +43,7 @@ import { jsonweaver } from "jsonweaver";
 
 ### Examples
 
-JSON to CSV (Basic usage, no custom headers, no flatten):
+#### JSON to CSV (Basic usage, no custom headers, no flatten):
 
 ```javascript
 const json = [
@@ -91,7 +93,7 @@ console.log(csvFlattened);
 */
 ```
 
-JSON to XML
+#### JSON to XML
 
 ```javascript
 const json = { name: "Alice", age: 25, city: "Wonderland" };
@@ -100,7 +102,7 @@ const xml = jsonweaver.toXML(json);
 console.log(xml);
 ```
 
-JSON to Markdown Table
+#### JSON to Markdown Table
 
 ```javascript
 const json = [
@@ -112,6 +114,55 @@ const markdownTable = jsonweaver.toMarkdownTable(json);
 console.log(markdownTable);
 ```
 
+#### JSON to YAML
+
+```javascript
+const json = { name: "Alice", age: 25, city: "Wonderland" };
+
+const yaml = jsonweaver.toYaml(json);
+console.log(yaml);
+/*
+name: Alice
+age: 25
+city: Wonderland
+*/
+```
+
+#### JSON to JSONLines (NDJSON)
+
+```javascript
+const json = [
+  { name: "Alice", age: 25 },
+  { name: "Bob", age: 30 },
+];
+
+const jsonLines = jsonweaver.toJsonLines(json);
+console.log(jsonLines);
+/*
+{"name":"Alice","age":25}
+{"name":"Bob","age":30}
+*/
+```
+
+JSON to JSONLines Stream
+
+```javascript
+const json = [
+  { name: "Alice", age: 25 },
+  { name: "Bob", age: 30 },
+];
+
+const stream = jsonweaver.toJsonLinesStream(json);
+
+stream.on("data", (chunk) => {
+  console.log(chunk.toString());
+});
+
+stream.on("end", () => {
+  console.log("Stream ended.");
+});
+```
+
 ### API
 
 | Function                                   | Description                                                                                                         |
@@ -119,6 +170,9 @@ console.log(markdownTable);
 | `toCSV(json: object[], headerMap?, opts?)` | Converts an array of JSON objects into a CSV string. Supports optional header mapping and nested object flattening. |
 | `toXML(json: object)`                      | Converts a JSON object into an XML string.                                                                          |
 | `toMarkdownTable(json: object[])`          | Converts an array of JSON objects into a formatted Markdown table.                                                  |
+| `toYaml(json: object)`                     | Converts a JSON object into a YAML string.                                                                          |
+| `toJsonLines(json: object[])`              | Converts an array of JSON objects into JSONLines (NDJSON) format.                                                   |
+| `toJsonLinesStream(json: object[])`        | Creates a readable stream of JSONLines from an array of JSON objects.                                               |
 
 **headerMap**: is an object mapping JSON keys to custom column labels.
 **opts?.flatten**: is a boolean indicating whether to flatten nested objects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "jsonweaver",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonweaver",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
+        "js-yaml": "^4.1.0",
         "xmlbuilder": "^15.1.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
+        "@types/js-yaml": "^4.0.9",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.2"
@@ -538,6 +540,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1013,6 +1039,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.10.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
@@ -1104,14 +1137,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -2785,14 +2814,12 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "jsonweaver",
-  "version": "1.0.2",
-  "description": "A simple utility to transform JSON data into CSV, XML, and Markdown table formats.",
+  "version": "1.1.0",
+  "description": "A simple utility to transform JSON data into CSV, XML, YAML, JSONLines and Markdown table formats.",
   "keywords": [
-    "json",
-    "data",
-    "format",
     "csv",
     "xml",
+    "json",
+    "data",
+    "yaml",
+    "format",
     "markdown",
+    "json-lines",
     "jsonweaver",
     "data-transform"
   ],
@@ -39,10 +41,12 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "xmlbuilder": "^15.1.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/js-yaml": "^4.0.9",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.2"

--- a/src/converters/toCSV.ts
+++ b/src/converters/toCSV.ts
@@ -1,7 +1,7 @@
-import { FieldGenerator, HeaderMapping, JSONArray, JSONObject } from '../types';
+import { FieldGenerator, HeaderMapping, JsonArray, JsonObject } from '../types';
 
-const defaultCSVFieldGenerator: FieldGenerator = (json) => {
-  const allKeys = Array.from(new Set(json.flatMap(item => Object.keys(item))));
+const defaultCSVFieldGenerator: FieldGenerator = (Json) => {
+  const allKeys = Array.from(new Set(Json.flatMap(item => Object.keys(item))));
 
   return allKeys.map(key => ({
     label: key,
@@ -18,8 +18,8 @@ export const customCSVFieldGenerator = (headerMapping: HeaderMapping): FieldGene
   };
 };
 
-const flattenObject = (obj: JSONObject, prefix = ''): JSONObject => {
-  return Object.entries(obj).reduce((acc: JSONObject, [key, value]) => {
+const flattenObject = (obj: JsonObject, prefix = ''): JsonObject => {
+  return Object.entries(obj).reduce((acc: JsonObject, [key, value]) => {
     const newKey = prefix ? `${prefix}.${key}` : key;
 
     if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -32,26 +32,26 @@ const flattenObject = (obj: JSONObject, prefix = ''): JSONObject => {
   }, {});
 };
 
-const flattenJSON = (json: JSONArray): JSONArray => {
-  return json.map((item) => flattenObject(item as JSONObject));
+const flattenJson = (Json: JsonArray): JsonArray => {
+  return Json.map((item) => flattenObject(item as JsonObject));
 };
 
 export const toCSV = (
-  json: JSONArray,
+  Json: JsonArray,
   fieldGenerator: FieldGenerator = defaultCSVFieldGenerator
 ): string => {
-  if (json.length === 0) return '';
+  if (Json.length === 0) return '';
 
-  const flattenedJSON = flattenJSON(json);
+  const flattenedJson = flattenJson(Json);
 
-  const allObjectsEmpty = flattenedJSON.every(item => Object.keys(item).length === 0);
+  const allObjectsEmpty = flattenedJson.every(item => Object.keys(item).length === 0);
   if (allObjectsEmpty) return '';
 
-  const fields = fieldGenerator(flattenedJSON);
+  const fields = fieldGenerator(flattenedJson);
 
   const headers = fields.map(field => `"${field.label}"`).join(',');
 
-  const rows = flattenedJSON.map((row) =>
+  const rows = flattenedJson.map((row) =>
     fields
       .map((field) => {
         const value = row[field.value as string];

--- a/src/converters/toJsonLines.ts
+++ b/src/converters/toJsonLines.ts
@@ -1,0 +1,33 @@
+import { Readable } from 'stream';
+import { JsonLinesObject, ToJsonLinesOptions } from '../types';
+
+export function toJsonLines(
+  jsonArray: JsonLinesObject[],
+  options?: ToJsonLinesOptions
+): string {
+  if (!Array.isArray(jsonArray)) {
+    throw new Error('Input must be an array of JSON objects.');
+  }
+
+  if (!jsonArray.every(item => item && typeof item === 'object' && !Array.isArray(item))) {
+    throw new Error('All elements in the array must be valid JSON objects.');
+  }
+
+  const { indent = 0, excludeKeys = [] } = options || {};
+
+  return jsonArray
+    .map(obj => {
+      const filteredObj = { ...obj };
+      excludeKeys.forEach(key => delete filteredObj[key]);
+      return JSON.stringify(filteredObj, null, indent);
+    })
+    .join('\n');
+};
+
+export function toJsonLinesStream(jsonArray: object[]): Readable {
+  if (!Array.isArray(jsonArray)) {
+      throw new Error('Input must be an array of JSON objects.');
+  }
+
+  return Readable.from(jsonArray.map(obj => JSON.stringify(obj) + '\n'));
+};

--- a/src/converters/toMarkdownTable.ts
+++ b/src/converters/toMarkdownTable.ts
@@ -1,6 +1,6 @@
-import { JSONArray } from '../types';
+import { JsonArray } from '../types';
 
-export const toMarkdownTable = (json: JSONArray): string => {
+export const toMarkdownTable = (json: JsonArray): string => {
   if (json.length === 0) {
     throw new Error('Input JSON array is empty.');
   }

--- a/src/converters/toXML.ts
+++ b/src/converters/toXML.ts
@@ -1,7 +1,7 @@
 import { create } from 'xmlbuilder';
-import { ToXMLOptions, JSONObject } from '../types';
+import { ToXmlOptions, JsonObject } from '../types';
 
-export const toXML = (json: JSONObject, options: ToXMLOptions = {}): string => {
+export const toXML = (json: JsonObject, options: ToXmlOptions = {}): string => {
   if (typeof json !== 'object' || Array.isArray(json)) {
     throw new Error('Input must be a JSON object (not an array or primitive).');
   }
@@ -17,13 +17,13 @@ export const toXML = (json: JSONObject, options: ToXMLOptions = {}): string => {
       if (arrayHandling === 'wrap') {
         return { item: obj.map((item) => buildXML(item, depth + 1)) };
       } else if (arrayHandling === 'index') {
-        return obj.reduce((acc: JSONObject, item, index) => {
+        return obj.reduce((acc: JsonObject, item, index) => {
           acc[`item${index}`] = buildXML(item, depth + 1);
           return acc;
         }, {});
       }
     } else if (typeof obj === 'object' && obj !== null) {
-      return Object.entries(obj).reduce((acc: JSONObject, [key, value]) => {
+      return Object.entries(obj).reduce((acc: JsonObject, [key, value]) => {
         acc[key] = buildXML(value, depth + 1);
         return acc;
       }, {});

--- a/src/converters/toYaml.ts
+++ b/src/converters/toYaml.ts
@@ -1,0 +1,35 @@
+import * as yaml from 'js-yaml';
+import { CustomErrorType, JsonObject, toYamlOptions } from '../types';
+import { createCustomError } from '../utils/errors';
+
+export function toYaml(jsonInput: string | JsonObject, options?: toYamlOptions): string {
+  const { sortKeys = false, noRefs = true } = options || {};
+  let jsonData: JsonObject;
+
+  try {
+    if (typeof jsonInput === 'string') {
+      jsonData = JSON.parse(jsonInput);
+    } else if (typeof jsonInput === 'object' && jsonInput !== null) {
+      jsonData = jsonInput;
+    } else {
+      const error = createCustomError('Input must be a valid JSON string or object.', 400);
+      throw error;
+    }
+
+    return yaml.dump(jsonData, {
+      noRefs,
+      sortKeys,
+    });
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      const customError = createCustomError('Invalid JSON format.', 400);
+      throw customError;
+    } else if (error && typeof (error as CustomErrorType).message === 'string') {
+      const customError = createCustomError(`Conversion error: ${(error as CustomErrorType).message}`, 500);
+      throw customError;
+    } else {
+      const customError = createCustomError('An unknown error occurred.', 500);
+      throw customError;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
+import { toJsonLines, toJsonLinesStream } from './converters/toJsonLines';
 import { toMarkdownTable } from './converters/toMarkdownTable';
+import { toYaml } from './converters/toYaml';
 import { toCSV } from './converters/toCSV';
 import { toXML } from './converters/toXML';
 
 export const jsonweaver = {
+  toJsonLinesStream,
   toMarkdownTable,
+  toJsonLines,
+  toYaml,
   toCSV,
   toXML,
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,11 @@
-export type JSONObject = Record<string, any>;
-export type JSONArray = JSONObject[];
+export type JsonObject = Record<string, any>;
+export type JsonArray = JsonObject[];
 
 export interface HeaderMapping {
   [key: string]: string;
 }
 
-export type ToXMLOptions = {
+export type ToXmlOptions = {
   maxDepth?: number;
   arrayHandling?: 'wrap' | 'index';
 };
@@ -15,4 +15,23 @@ type Field = {
   value: string | ((row: Record<string, any>) => string);
 };
 
-export type FieldGenerator = (json: JSONArray) => Field[];
+export type FieldGenerator = (json: JsonArray) => Field[];
+
+export type toYamlOptions = {
+  sortKeys?: boolean;
+  noRefs?: boolean;
+};
+
+export type ToJsonLinesOptions = {
+  indent?: number;
+  excludeKeys?: string[];
+};
+
+export type CustomErrorType = {
+  message: string;
+  code: number;
+};
+
+export type JsonLinesObject = {
+  [key: string]: any;
+};

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,5 @@
+import { CustomErrorType } from "../types";
+
+export function createCustomError(message: string, code: number): CustomErrorType {
+  return { message, code };
+}

--- a/tests/toJsonLines.test.ts
+++ b/tests/toJsonLines.test.ts
@@ -1,0 +1,140 @@
+import { toJsonLines, toJsonLinesStream } from '../src/converters/toJsonLines';
+
+describe('toJsonLines', () => {
+  it('should convert an array of JSON objects to JSONLines format', () => {
+    const jsonArray: Record<string, unknown>[] = [
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 30 },
+    ];
+
+    const expected = `{"name":"Alice","age":25}
+{"name":"Bob","age":30}`;
+    const result = toJsonLines(jsonArray);
+
+    expect(result).toBe(expected);
+  });
+
+  it('should handle nested objects and arrays', () => {
+    const jsonArray: Record<string, unknown>[] = [
+      { name: 'Alice', details: { age: 25, city: 'New York' } },
+      { name: 'Bob', hobbies: ['reading', 'traveling'] },
+    ];
+
+    const expected = `{"name":"Alice","details":{"age":25,"city":"New York"}}
+{"name":"Bob","hobbies":["reading","traveling"]}`;
+    const result = toJsonLines(jsonArray);
+
+    expect(result).toBe(expected);
+  });
+
+  it('should handle different data types', () => {
+    const jsonArray: Record<string, unknown>[] = [
+      { number: 42, boolean: true, nullValue: null, emptyObject: {} },
+    ];
+
+    const expected = `{"number":42,"boolean":true,"nullValue":null,"emptyObject":{}}`;
+    const result = toJsonLines(jsonArray);
+
+    expect(result).toBe(expected);
+  });
+
+  it('should handle an empty array', () => {
+    const jsonArray: Record<string, unknown>[] = [];
+    const expected = '';
+    const result = toJsonLines(jsonArray);
+
+    expect(result).toBe(expected);
+  });
+
+  it('should handle large volumes of data', () => {
+    const jsonArray = Array.from({ length: 1000 }, (_, i) => ({ id: i }));
+
+    const result = toJsonLines(jsonArray);
+
+    expect(result.startsWith('{"id":0}')).toBe(true);
+    expect(result.endsWith('{"id":999}')).toBe(true);
+  });
+
+  it('should handle numeric keys in objects', () => {
+    const jsonArray: Record<string, unknown>[] = [
+      { '123': 'value' },
+    ];
+
+    const expected = `{"123":"value"}`;
+    const result = toJsonLines(jsonArray);
+
+    expect(result).toBe(expected);
+  });
+
+  it('should exclude specified keys from the objects', () => {
+    const jsonArray: Record<string, unknown>[] = [
+      { name: 'Alice', age: 25, city: 'New York' },
+      { name: 'Bob', age: 30, city: 'Los Angeles' },
+    ];
+
+    const options = { excludeKeys: ['city'] };
+    const expected = `{"name":"Alice","age":25}
+{"name":"Bob","age":30}`;
+    const result = toJsonLines(jsonArray, options);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe('toJsonLinesStream', () => {
+  it('should create a readable stream of JSONLines', async () => {
+    const jsonArray: Record<string, unknown>[] = [
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 30 },
+    ];
+
+    const stream = toJsonLinesStream(jsonArray);
+    const chunks: string[] = [];
+
+    for await (const chunk of stream) {
+      chunks.push(chunk.toString());
+    }
+
+    const expected = `{"name":"Alice","age":25}
+{"name":"Bob","age":30}
+`;
+    expect(chunks.join('')).toBe(expected);
+  });
+
+  it('should handle nested objects and arrays in stream', async () => {
+    const jsonArray: Record<string, unknown>[] = [
+      { name: 'Alice', details: { age: 25, city: 'New York' } },
+      { name: 'Bob', hobbies: ['reading', 'traveling'] },
+    ];
+
+    const stream = toJsonLinesStream(jsonArray);
+    const chunks: string[] = [];
+
+    for await (const chunk of stream) {
+      chunks.push(chunk.toString());
+    }
+
+    const expected = `{"name":"Alice","details":{"age":25,"city":"New York"}}
+{"name":"Bob","hobbies":["reading","traveling"]}
+`;
+    expect(chunks.join('')).toBe(expected);
+  });
+
+  it('should handle an empty array and produce an empty stream', async () => {
+    const jsonArray: Record<string, unknown>[] = [];
+    const stream = toJsonLinesStream(jsonArray);
+    const chunks: string[] = [];
+
+    for await (const chunk of stream) {
+      chunks.push(chunk.toString());
+    }
+
+    expect(chunks.join('')).toBe('');
+  });
+
+  it('should throw an error if the input is not an array', () => {
+    expect(() => toJsonLinesStream(null as unknown as Record<string, unknown>[])).toThrow(
+      'Input must be an array of JSON objects.'
+    );
+  });
+});

--- a/tests/toYaml.test.ts
+++ b/tests/toYaml.test.ts
@@ -1,0 +1,115 @@
+import { toYaml } from '../src/converters/toYaml';
+
+describe('toYaml', () => {
+  it('should convert a JSON object to YAML format', () => {
+    const jsonInput = {
+      name: 'JsonWeaver',
+      version: '1.0.3',
+      features: ['JSON to YAML Conversion'],
+    };
+
+    const expectedYaml = `name: JsonWeaver\nversion: 1.0.3\nfeatures:\n  - JSON to YAML Conversion\n`;
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+
+  it('should handle empty JSON objects', () => {
+    const jsonInput = {};
+    const expectedYaml = '{}\n';
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+
+  it('should throw an error for invalid inputs', () => {
+    expect(() => toYaml(null as unknown as object)).toThrow(
+      'Conversion error: Input must be a valid JSON string or object.'
+    );
+    expect(() => toYaml(undefined as unknown as object)).toThrow(
+      'Conversion error: Input must be a valid JSON string or object.'
+    );
+  });
+
+  it('should correctly handle nested JSON objects', () => {
+    const jsonInput = {
+      person: {
+        name: 'John',
+        address: {
+          city: 'New York',
+          zip: '10001',
+        },
+      },
+    };
+
+    const expectedYaml = `person:\n  name: John\n  address:\n    city: New York\n    zip: '10001'\n`;
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+
+  it('should correctly handle arrays in JSON objects', () => {
+    const jsonInput = {
+      items: ['item1', 'item2', 'item3'],
+    };
+
+    const expectedYaml = `items:\n  - item1\n  - item2\n  - item3\n`;
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+
+  it('should handle numbers, booleans, and null', () => {
+    const jsonInput = {
+      number: 42,
+      boolean: true,
+      nullValue: null,
+    };
+
+    const expectedYaml = `number: 42\nboolean: true\nnullValue: null\n`;
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+
+  it('should handle strings with special characters', () => {
+    const jsonInput = {
+      text: 'Line1\nLine2',
+      emoji: '😊',
+    };
+
+    const expectedYaml = `text: |-\n  Line1\n  Line2\nemoji: 😊\n`;
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+
+
+  it('should handle large JSON objects', () => {
+    const jsonInput = Array.from({ length: 1000 }, (_, i) => ({ index: i }));
+
+    expect(() => toYaml(jsonInput)).not.toThrow();
+  });
+
+  it('should produce consistent YAML output for YAML-like input', () => {
+    const jsonInput = {
+      yamlLike: `key: value`,
+    };
+
+    const expectedYaml = `yamlLike: 'key: value'\n`;
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+
+  it('should handle numeric keys in objects', () => {
+    const jsonInput = {
+      123: 'value',
+    };
+
+    const expectedYaml = `'123': value\n`;
+
+    const yamlOutput = toYaml(jsonInput);
+    expect(yamlOutput).toBe(expectedYaml);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "strict": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "moduleResolution": "node"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This pull request introduces three major features for the upcoming v1.1.0 release of `jsonweaver`:

- JSON to YAML Conversion: Easily transform JSON objects into YAML format, ideal for use cases like Kubernetes and Ansible configurations.
- JSON to JSONLines (NDJSON): Convert JSON arrays into JSONLines format, optimized for incremental data processing and streaming pipelines.
- JSONLines Stream: Generate readable streams of JSONLines to efficiently handle large datasets.

Additionally, this release includes improvements in input validation and memory optimization for handling large JSON transformations. 🚀